### PR TITLE
Use a less glaring colour to highlight footnote

### DIFF
--- a/_sass/colors/typography-light.scss
+++ b/_sass/colors/typography-light.scss
@@ -69,7 +69,7 @@
   --card-hovor-bg: #e2e2e2;
   --card-shadow: rgb(104, 104, 104, 0.05) 0 2px 6px 0,
     rgba(211, 209, 209, 0.15) 0 0 0 1px;
-  --footnote-target-bg: lightcyan;
+  --footnote-target-bg: #eaf1f3;
   --tb-odd-bg: #fbfcfd;
   --tb-border-color: #eaeaea;
   --dash-color: silver;


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description

The current colour to hightlight a footnote is the neon colour `lightcyan`, which can be glaring and places strain on the eyes.  Change the highlight colour to a non-neon colour.

## Additional context
 None.
